### PR TITLE
Refactor solution structure for APIs and telemetry library

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*.cs]
+indent_style = space
+indent_size = 4
+csharp_style_expression_bodied_methods = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_namespace_declarations = file_scoped:suggestion
+csharp_prefer_static_local_function = true:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+
+[*.{csproj,props,targets}]
+indent_size = 2
+indent_style = space

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,11 @@
+<Project>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <LangVersion>latest</LangVersion>
+    <AnalysisLevel>latest-all</AnalysisLevel>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+</Project>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,93 @@
+# TelemetryBridge Demo
+
+TelemetryBridge Demo showcases a reusable OpenTelemetry bootstrapper for .NET 8 services. The solution contains:
+
+- **TelemetryBridge** – class library that wires tracing, metrics, and developer log mirroring.
+- **Todo.MainApi** – public facing API that proxies todo requests to the downstream service.
+- **Todo.DownstreamApi** – in-memory todo API that exposes CRUD endpoints and emits custom metrics.
+- **Todo.Worker** – background worker exercising telemetry outside of ASP.NET Core.
+- **OtelCollector** – Dockerized OpenTelemetry Collector configured for Azure Application Insights.
+
+## Prerequisites
+
+- .NET SDK 8.0+
+- Docker Desktop (with Linux containers enabled)
+
+## Building
+
+```bash
+dotnet build TelemetryBridgeDemo.sln -warnaserror
+```
+
+## Running locally
+
+1. Start the OpenTelemetry Collector (only needs to run once):
+
+   ```bash
+   docker compose up --build -d
+   ```
+
+   Replace the `APPLICATIONINSIGHTS_CONNECTION_STRING` value in `docker-compose.yml` with a real Application Insights connection string before running in a real environment.
+
+2. Run the downstream API:
+
+   ```bash
+   dotnet run --project src/Todo.DownstreamApi
+   ```
+
+3. In a new terminal, run the main API:
+
+   ```bash
+   dotnet run --project src/Todo.MainApi
+   ```
+
+4. In another terminal, run the worker service:
+
+   ```bash
+   dotnet run --project src/Todo.Worker
+   ```
+
+## Smoke testing
+
+With the downstream API listening on `http://localhost:5071` and the main API on `http://localhost:5072`, try the following commands:
+
+```bash
+curl http://localhost:5071/health
+curl http://localhost:5072/health
+curl http://localhost:5072/todo
+curl -X POST http://localhost:5072/todo \
+  -H "Content-Type: application/json" \
+  -d '{"title":"demo"}'
+```
+
+Each API call is automatically traced. Developer logs from the `Todo.*` namespaces are attached to spans as events and shipped to the collector alongside traces and metrics via OTLP gRPC (`http://localhost:4317` by default). Override the OTLP endpoint and protocol using the `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_PROTOCOL` environment variables if needed.
+
+The worker continuously emits telemetry every 10 seconds, demonstrating non-HTTP consumers.
+
+## Telemetry pipeline
+
+```
+Todo services & worker → OTLP (4317/4318) → OpenTelemetry Collector → Azure Application Insights
+```
+
+The collector forwards traces, metrics, and filtered logs (dropping `Microsoft.*` and `System.*` categories) to Application Insights.
+
+## Project layout
+
+```
+TelemetryBridgeDemo.sln
+├── src/
+│   ├── TelemetryBridge/          # reusable library
+│   ├── Todo.MainApi/             # main API
+│   ├── Todo.DownstreamApi/       # downstream API
+│   ├── Todo.Worker/              # background worker
+│   └── OtelCollector/            # collector Docker assets
+├── tests/
+│   └── TelemetryBridge.Tests/    # unit tests for the library
+├── docker-compose.yml
+└── README.md
+```
+
+## Logging and correlation
+
+TelemetryBridge does not add or replace any logger providers. Instead, it decorates `ILogger<T>` to mirror developer logs into active spans as `ActivityEvent` instances, while lightweight middleware and `HttpClient` handlers flow trace identifiers through `ILogger` scopes. Existing logging stacks (Console, Serilog, etc.) continue to function unchanged.

--- a/TelemetryBridgeDemo.sln
+++ b/TelemetryBridgeDemo.sln
@@ -1,0 +1,52 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TelemetryBridge", "src\\TelemetryBridge\\TelemetryBridge.csproj", "{2BDC6B0F-A58D-4577-AB3F-4ACC080DD62C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Todo.MainApi", "src\\Todo.MainApi\\Todo.MainApi.csproj", "{1B208C8F-F24D-448B-AC2F-0368364EC193}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Todo.DownstreamApi", "src\\Todo.DownstreamApi\\Todo.DownstreamApi.csproj", "{EB77E6AE-F9CE-41CB-8535-A8C7BB31D460}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Todo.Worker", "src\\Todo.Worker\\Todo.Worker.csproj", "{30FF742D-56A7-4832-A607-94F5D9414E4A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TelemetryBridge.Tests", "tests\\TelemetryBridge.Tests\\TelemetryBridge.Tests.csproj", "{769DC376-00A7-4940-8B43-9F02987463A5}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A3653FEC-E87F-4820-9371-DDB78100BDCB}"
+ProjectSection(SolutionItems) = preProject
+.editorconfig = .editorconfig
+README.md = README.md
+docker-compose.yml = docker-compose.yml
+EndProjectSection
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{2BDC6B0F-A58D-4577-AB3F-4ACC080DD62C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{2BDC6B0F-A58D-4577-AB3F-4ACC080DD62C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{2BDC6B0F-A58D-4577-AB3F-4ACC080DD62C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{2BDC6B0F-A58D-4577-AB3F-4ACC080DD62C}.Release|Any CPU.Build.0 = Release|Any CPU
+{1B208C8F-F24D-448B-AC2F-0368364EC193}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{1B208C8F-F24D-448B-AC2F-0368364EC193}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{1B208C8F-F24D-448B-AC2F-0368364EC193}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{1B208C8F-F24D-448B-AC2F-0368364EC193}.Release|Any CPU.Build.0 = Release|Any CPU
+{EB77E6AE-F9CE-41CB-8535-A8C7BB31D460}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{EB77E6AE-F9CE-41CB-8535-A8C7BB31D460}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{EB77E6AE-F9CE-41CB-8535-A8C7BB31D460}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{EB77E6AE-F9CE-41CB-8535-A8C7BB31D460}.Release|Any CPU.Build.0 = Release|Any CPU
+{30FF742D-56A7-4832-A607-94F5D9414E4A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{30FF742D-56A7-4832-A607-94F5D9414E4A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{30FF742D-56A7-4832-A607-94F5D9414E4A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{30FF742D-56A7-4832-A607-94F5D9414E4A}.Release|Any CPU.Build.0 = Release|Any CPU
+{769DC376-00A7-4940-8B43-9F02987463A5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{769DC376-00A7-4940-8B43-9F02987463A5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{769DC376-00A7-4940-8B43-9F02987463A5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{769DC376-00A7-4940-8B43-9F02987463A5}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+GlobalSection(SolutionProperties) = preSolution
+HideSolutionNode = FALSE
+EndGlobalSection
+EndGlobal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3.9"
+
+services:
+  otel-collector:
+    build:
+      context: ./src/OtelCollector
+    environment:
+      APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://example.ai"
+    ports:
+      - "4317:4317"
+      - "4318:4318"
+      - "13133:13133"

--- a/src/OtelCollector/Dockerfile
+++ b/src/OtelCollector/Dockerfile
@@ -1,0 +1,5 @@
+FROM otel/opentelemetry-collector:0.88.0
+
+COPY otel-collector-config.yaml /etc/otel-collector-config.yaml
+
+ENTRYPOINT ["/otelcol", "--config", "/etc/otel-collector-config.yaml"]

--- a/src/OtelCollector/otel-collector-config.yaml
+++ b/src/OtelCollector/otel-collector-config.yaml
@@ -1,0 +1,44 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+processors:
+  batch: {}
+  filter/drop_framework_logs:
+    logs:
+      exclude:
+        match_type: regexp
+        attributes:
+          - key: log.category
+            value: ^(Microsoft|System)\.
+          - key: logger.category
+            value: ^(Microsoft|System)\.
+  filter/keep_app_severity:
+    logs:
+      include:
+        match_type: strict
+        severity_texts: [INFO, WARN, ERROR, FATAL]
+
+exporters:
+  azuremonitor:
+    connection_string: ${APPLICATIONINSIGHTS_CONNECTION_STRING}
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [azuremonitor]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [azuremonitor]
+    logs:
+      receivers: [otlp]
+      processors: [filter/drop_framework_logs, filter/keep_app_severity, batch]
+      exporters: [azuremonitor]
+  telemetry:
+    logs:
+      level: "info"

--- a/src/TelemetryBridge/Abstractions/IMetricsHandle.cs
+++ b/src/TelemetryBridge/Abstractions/IMetricsHandle.cs
@@ -1,0 +1,31 @@
+using System.Diagnostics.Metrics;
+
+namespace TelemetryBridge;
+
+/// <summary>
+/// Exposes helper APIs for creating reusable metrics instruments tied to the application's meter.
+/// </summary>
+public interface IMetricsHandle
+{
+    /// <summary>
+    /// Gets the shared <see cref="Meter"/> instance.
+    /// </summary>
+    Meter Meter { get; }
+
+    /// <summary>
+    /// Creates or returns a cached <see cref="Counter{T}"/> instrument.
+    /// </summary>
+    /// <param name="name">The instrument name.</param>
+    /// <param name="unit">An optional measurement unit.</param>
+    /// <param name="description">An optional description.</param>
+    /// <returns>The counter instrument.</returns>
+    Counter<long> CreateCounter(string name, string? unit = null, string? description = null);
+
+    /// <summary>
+    /// Creates or returns a cached <see cref="Histogram{T}"/> instrument.</summary>
+    /// <param name="name">The instrument name.</param>
+    /// <param name="unit">An optional measurement unit.</param>
+    /// <param name="description">An optional description.</param>
+    /// <returns>The histogram instrument.</returns>
+    Histogram<double> CreateHistogram(string name, string? unit = null, string? description = null);
+}

--- a/src/TelemetryBridge/Extensions/TelemetryBridgeServiceCollectionExtensions.cs
+++ b/src/TelemetryBridge/Extensions/TelemetryBridgeServiceCollectionExtensions.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Threading;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using OpenTelemetry;
+using OpenTelemetry.Context.Propagation;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+using TelemetryBridge.Internal.Configuration;
+using TelemetryBridge.Internal.Diagnostics;
+using TelemetryBridge.Internal.Logging;
+
+namespace TelemetryBridge;
+
+/// <summary>
+/// Extension methods for wiring the Telemetry Bridge into an application.
+/// </summary>
+public static class TelemetryBridgeServiceCollectionExtensions
+{
+    private static int _propagatorInitialized;
+
+    /// <summary>
+    /// Registers OpenTelemetry tracing and metrics along with developer log mirroring.
+    /// </summary>
+    /// <param name="services">The target service collection.</param>
+    /// <param name="serviceName">The logical service name used for telemetry resources.</param>
+    /// <returns>The same <see cref="IServiceCollection"/> for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="services"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="serviceName"/> is empty.</exception>
+    public static IServiceCollection AddTelemetryBridge(this IServiceCollection services, string serviceName)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        if (string.IsNullOrWhiteSpace(serviceName))
+        {
+            throw new ArgumentException("Service name must be provided.", nameof(serviceName));
+        }
+
+        serviceName = serviceName.Trim();
+
+        EnsurePropagator();
+
+        var options = TelemetryBridgeOptions.Create(serviceName);
+
+        services.TryAddSingleton(options);
+        services.TryAddSingleton(_ => options.CreateActivitySource());
+        services.TryAddSingleton(_ => options.CreateMeter());
+        services.TryAddSingleton<IMetricsHandle, MetricsHandle>();
+        services.TryAddSingleton<ITelemetryLogEventEmitter, TelemetryLogEventEmitter>();
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IStartupFilter, TraceScopeStartupFilter>());
+        services.TryAddTransient<TraceScopeMiddleware>();
+        services.TryAddTransient<TraceScopeHandler>();
+        services.TryAddEnumerable(ServiceDescriptor.Transient<IConfigureOptions<HttpClientFactoryOptions>, TraceScopeHttpClientOptions>());
+
+        services.Replace(ServiceDescriptor.Singleton(typeof(ILogger<>), typeof(TelemetryLogger<>)));
+
+        services.AddOpenTelemetry()
+            .ConfigureResource(resourceBuilder => TelemetryResourceBuilder.Configure(resourceBuilder, options))
+            .WithTracing(tracerProviderBuilder =>
+            {
+                tracerProviderBuilder
+                    .AddSource(options.ServiceName)
+                    .AddAspNetCoreInstrumentation()
+                    .AddHttpClientInstrumentation()
+                    .AddGrpcClientInstrumentation()
+                    .AddGrpcCoreInstrumentation()
+                    .SetSampler(new AlwaysOnSampler())
+                    .AddOtlpExporter(options => OtlpExporterOptionsResolver.Configure(options));
+            })
+            .WithMetrics(meterProviderBuilder =>
+            {
+                meterProviderBuilder
+                    .AddMeter(options.ServiceName)
+                    .AddRuntimeInstrumentation()
+                    .AddProcessInstrumentation()
+                    .AddAspNetCoreInstrumentation()
+                    .AddHttpClientInstrumentation()
+                    .AddOtlpExporter(options => OtlpExporterOptionsResolver.Configure(options));
+            });
+
+        return services;
+    }
+
+    private static void EnsurePropagator()
+    {
+        if (Interlocked.Exchange(ref _propagatorInitialized, 1) == 1)
+        {
+            return;
+        }
+
+        Sdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
+        {
+            new TraceContextPropagator(),
+            new BaggagePropagator(),
+        }));
+    }
+}

--- a/src/TelemetryBridge/Internal/Configuration/OtlpExporterOptionsResolver.cs
+++ b/src/TelemetryBridge/Internal/Configuration/OtlpExporterOptionsResolver.cs
@@ -1,0 +1,38 @@
+using System;
+using OpenTelemetry.Exporter;
+
+namespace TelemetryBridge.Internal.Configuration;
+
+/// <summary>
+/// Resolves OTLP exporter configuration from environment variables.
+/// </summary>
+internal static class OtlpExporterOptionsResolver
+{
+    private const string EndpointVariable = "OTEL_EXPORTER_OTLP_ENDPOINT";
+    private const string ProtocolVariable = "OTEL_EXPORTER_OTLP_PROTOCOL";
+
+    public static void Configure(OtlpExporterOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var endpointText = Environment.GetEnvironmentVariable(EndpointVariable);
+        if (!string.IsNullOrWhiteSpace(endpointText) && Uri.TryCreate(endpointText, UriKind.Absolute, out var endpoint))
+        {
+            options.Endpoint = endpoint;
+        }
+        else
+        {
+            options.Endpoint = new Uri("http://localhost:4317", UriKind.Absolute);
+        }
+
+        var protocolText = Environment.GetEnvironmentVariable(ProtocolVariable);
+        if (!string.IsNullOrWhiteSpace(protocolText) && Enum.TryParse(protocolText, ignoreCase: true, out OtlpExportProtocol protocol))
+        {
+            options.Protocol = protocol;
+        }
+        else
+        {
+            options.Protocol = OtlpExportProtocol.Grpc;
+        }
+    }
+}

--- a/src/TelemetryBridge/Internal/Configuration/TelemetryBridgeOptions.cs
+++ b/src/TelemetryBridge/Internal/Configuration/TelemetryBridgeOptions.cs
@@ -1,0 +1,35 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Reflection;
+
+namespace TelemetryBridge.Internal.Configuration;
+
+/// <summary>
+/// Configuration container that keeps shared telemetry settings.
+/// </summary>
+internal sealed class TelemetryBridgeOptions
+{
+    private TelemetryBridgeOptions(string serviceName, string serviceVersion, string developerLogCategoryPrefix)
+    {
+        ServiceName = serviceName;
+        ServiceVersion = serviceVersion;
+        DeveloperLogCategoryPrefix = developerLogCategoryPrefix;
+    }
+
+    public string ServiceName { get; }
+
+    public string ServiceVersion { get; }
+
+    public string DeveloperLogCategoryPrefix { get; }
+
+    public static TelemetryBridgeOptions Create(string serviceName)
+    {
+        var entryAssembly = Assembly.GetEntryAssembly();
+        var version = entryAssembly?.GetName().Version?.ToString() ?? typeof(TelemetryBridgeOptions).Assembly.GetName().Version?.ToString() ?? "1.0.0";
+        return new TelemetryBridgeOptions(serviceName, version, developerLogCategoryPrefix: serviceName);
+    }
+
+    public ActivitySource CreateActivitySource() => new(ServiceName);
+
+    public Meter CreateMeter() => new(ServiceName);
+}

--- a/src/TelemetryBridge/Internal/Diagnostics/MetricsHandle.cs
+++ b/src/TelemetryBridge/Internal/Diagnostics/MetricsHandle.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
+using TelemetryBridge;
+
+namespace TelemetryBridge.Internal.Diagnostics;
+
+/// <summary>
+/// Default implementation of <see cref="IMetricsHandle"/> that caches instrument instances.
+/// </summary>
+internal sealed class MetricsHandle : IMetricsHandle, IDisposable
+{
+    private readonly ConcurrentDictionary<string, Instrument> _instruments = new(StringComparer.Ordinal);
+    private bool _disposed;
+
+    public MetricsHandle(Meter meter)
+    {
+        Meter = meter ?? throw new ArgumentNullException(nameof(meter));
+    }
+
+    public Meter Meter { get; }
+
+    public Counter<long> CreateCounter(string name, string? unit = null, string? description = null)
+    {
+        EnsureNotDisposed();
+        return (Counter<long>)_instruments.GetOrAdd(name, _ => Meter.CreateCounter<long>(name, unit, description));
+    }
+
+    public Histogram<double> CreateHistogram(string name, string? unit = null, string? description = null)
+    {
+        EnsureNotDisposed();
+        return (Histogram<double>)_instruments.GetOrAdd(name, _ => Meter.CreateHistogram<double>(name, unit, description));
+    }
+
+    private void EnsureNotDisposed()
+    {
+        if (_disposed)
+        {
+            throw new ObjectDisposedException(nameof(MetricsHandle));
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        foreach (var instrument in _instruments.Values)
+        {
+            instrument.Dispose();
+        }
+
+        _disposed = true;
+    }
+}

--- a/src/TelemetryBridge/Internal/Diagnostics/TelemetryResourceBuilder.cs
+++ b/src/TelemetryBridge/Internal/Diagnostics/TelemetryResourceBuilder.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using OpenTelemetry.Resources;
+using TelemetryBridge.Internal.Configuration;
+
+namespace TelemetryBridge.Internal.Diagnostics;
+
+/// <summary>
+/// Builds consistent OpenTelemetry resources for the consuming application.
+/// </summary>
+internal static class TelemetryResourceBuilder
+{
+    public static void Configure(ResourceBuilder resourceBuilder, TelemetryBridgeOptions options)
+    {
+        resourceBuilder
+            .AddService(serviceName: options.ServiceName, serviceVersion: options.ServiceVersion)
+            .AddAttributes(new KeyValuePair<string, object?>[]
+            {
+                new("service.instance.id", Environment.MachineName),
+            });
+    }
+}

--- a/src/TelemetryBridge/Internal/Logging/ITelemetryLogEventEmitter.cs
+++ b/src/TelemetryBridge/Internal/Logging/ITelemetryLogEventEmitter.cs
@@ -1,0 +1,11 @@
+using Microsoft.Extensions.Logging;
+
+namespace TelemetryBridge.Internal.Logging;
+
+/// <summary>
+/// Provides a hook for mirroring developer log messages into the active <see cref="System.Diagnostics.Activity"/>.
+/// </summary>
+internal interface ITelemetryLogEventEmitter
+{
+    void Record<TState>(string category, LogLevel level, EventId eventId, TState state, Exception? exception, string message);
+}

--- a/src/TelemetryBridge/Internal/Logging/TelemetryLogEventEmitter.cs
+++ b/src/TelemetryBridge/Internal/Logging/TelemetryLogEventEmitter.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using TelemetryBridge.Internal.Configuration;
+
+namespace TelemetryBridge.Internal.Logging;
+
+/// <summary>
+/// Adds log entries as span events on the current activity.
+/// </summary>
+internal sealed class TelemetryLogEventEmitter : ITelemetryLogEventEmitter
+{
+    private readonly TelemetryBridgeOptions _options;
+
+    public TelemetryLogEventEmitter(TelemetryBridgeOptions options)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    public void Record<TState>(string category, LogLevel level, EventId eventId, TState state, Exception? exception, string message)
+    {
+        if (!ShouldCapture(category))
+        {
+            return;
+        }
+
+        var activity = Activity.Current;
+        if (activity is null)
+        {
+            return;
+        }
+
+        var tags = new ActivityTagsCollection
+        {
+            { "log.severity", level.ToString() },
+            { "log.category", category },
+            { "log.event_id", eventId.Id },
+        };
+
+        if (!string.IsNullOrWhiteSpace(eventId.Name))
+        {
+            tags.Add("log.event_name", eventId.Name!);
+        }
+
+        if (!string.IsNullOrWhiteSpace(message))
+        {
+            tags.Add("log.message", message);
+        }
+
+        if (exception is not null)
+        {
+            tags.Add("exception.type", exception.GetType().FullName ?? exception.GetType().Name);
+            tags.Add("exception.message", exception.Message);
+            tags.Add("exception.stacktrace", exception.StackTrace ?? string.Empty);
+        }
+
+        if (state is IEnumerable<KeyValuePair<string, object?>> structuredState)
+        {
+            foreach (var pair in structuredState)
+            {
+                if (pair.Key is null)
+                {
+                    continue;
+                }
+
+                tags[$"log.state.{pair.Key}"] = pair.Value;
+            }
+        }
+
+        activity.AddEvent(new ActivityEvent("log", tags));
+    }
+
+    private bool ShouldCapture(string category)
+        => !string.IsNullOrEmpty(category) && category.StartsWith(_options.DeveloperLogCategoryPrefix, StringComparison.Ordinal);
+}

--- a/src/TelemetryBridge/Internal/Logging/TelemetryLogger.cs
+++ b/src/TelemetryBridge/Internal/Logging/TelemetryLogger.cs
@@ -1,0 +1,44 @@
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace TelemetryBridge.Internal.Logging;
+
+/// <summary>
+/// Decorates the default logger to mirror developer log messages into the current activity.
+/// </summary>
+/// <typeparam name="T">The logger category type.</typeparam>
+internal sealed class TelemetryLogger<T> : ILogger<T>
+{
+    private readonly ILogger _innerLogger;
+    private readonly ITelemetryLogEventEmitter _emitter;
+    private readonly string _categoryName;
+
+    public TelemetryLogger(ILoggerFactory loggerFactory, ITelemetryLogEventEmitter emitter)
+    {
+        ArgumentNullException.ThrowIfNull(loggerFactory);
+        ArgumentNullException.ThrowIfNull(emitter);
+
+        _categoryName = typeof(T).FullName ?? typeof(T).Name;
+        _innerLogger = loggerFactory.CreateLogger(_categoryName);
+        _emitter = emitter;
+    }
+
+    public IDisposable? BeginScope<TState>(TState state)
+        where TState : notnull
+        => _innerLogger.BeginScope(state);
+
+    public bool IsEnabled(LogLevel logLevel) => _innerLogger.IsEnabled(logLevel);
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        if (!IsEnabled(logLevel))
+        {
+            return;
+        }
+
+        ArgumentNullException.ThrowIfNull(formatter);
+        var message = formatter(state, exception);
+        _emitter.Record(_categoryName, logLevel, eventId, state, exception, message);
+        _innerLogger.Log(logLevel, eventId, state, exception, formatter);
+    }
+}

--- a/src/TelemetryBridge/Internal/Logging/TraceScopeHandler.cs
+++ b/src/TelemetryBridge/Internal/Logging/TraceScopeHandler.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace TelemetryBridge.Internal.Logging;
+
+/// <summary>
+/// Adds trace context scopes for outbound HTTP calls created via <see cref="IHttpClientFactory"/>.
+/// </summary>
+internal sealed class TraceScopeHandler : DelegatingHandler
+{
+    private readonly ILogger<TraceScopeHandler> _logger;
+
+    public TraceScopeHandler(ILogger<TraceScopeHandler> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var activity = Activity.Current;
+        if (activity is null)
+        {
+            return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+
+        using (_logger.BeginScope(TraceScopeValues.Create(activity)))
+        {
+            return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/TelemetryBridge/Internal/Logging/TraceScopeHttpClientOptions.cs
+++ b/src/TelemetryBridge/Internal/Logging/TraceScopeHttpClientOptions.cs
@@ -1,0 +1,23 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http;
+using Microsoft.Extensions.Options;
+
+namespace TelemetryBridge.Internal.Logging;
+
+/// <summary>
+/// Ensures the trace scope handler participates in every <see cref="HttpClient"/> created by the factory.
+/// </summary>
+internal sealed class TraceScopeHttpClientOptions : IConfigureOptions<HttpClientFactoryOptions>
+{
+    public void Configure(HttpClientFactoryOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        options.HttpMessageHandlerBuilderActions.Add(builder =>
+        {
+            var handler = builder.Services.GetRequiredService<TraceScopeHandler>();
+            builder.AdditionalHandlers.Add(handler);
+        });
+    }
+}

--- a/src/TelemetryBridge/Internal/Logging/TraceScopeMiddleware.cs
+++ b/src/TelemetryBridge/Internal/Logging/TraceScopeMiddleware.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace TelemetryBridge.Internal.Logging;
+
+/// <summary>
+/// Ensures trace context is promoted to the logging scope for inbound requests.
+/// </summary>
+internal sealed class TraceScopeMiddleware : IMiddleware
+{
+    private readonly ILogger<TraceScopeMiddleware> _logger;
+
+    public TraceScopeMiddleware(ILogger<TraceScopeMiddleware> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(next);
+
+        var activity = Activity.Current;
+        if (activity is null)
+        {
+            await next(context).ConfigureAwait(false);
+            return;
+        }
+
+        using (_logger.BeginScope(TraceScopeValues.Create(activity)))
+        {
+            await next(context).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/TelemetryBridge/Internal/Logging/TraceScopeStartupFilter.cs
+++ b/src/TelemetryBridge/Internal/Logging/TraceScopeStartupFilter.cs
@@ -1,0 +1,21 @@
+using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+
+namespace TelemetryBridge.Internal.Logging;
+
+/// <summary>
+/// Automatically adds the <see cref="TraceScopeMiddleware"/> to the ASP.NET Core pipeline.
+/// </summary>
+internal sealed class TraceScopeStartupFilter : IStartupFilter
+{
+    public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
+    {
+        return app =>
+        {
+            ArgumentNullException.ThrowIfNull(app);
+            app.UseMiddleware<TraceScopeMiddleware>();
+            next(app);
+        };
+    }
+}

--- a/src/TelemetryBridge/Internal/Logging/TraceScopeValues.cs
+++ b/src/TelemetryBridge/Internal/Logging/TraceScopeValues.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace TelemetryBridge.Internal.Logging;
+
+/// <summary>
+/// Helper that builds a logging scope dictionary with trace identifiers.
+/// </summary>
+internal static class TraceScopeValues
+{
+    public static IReadOnlyDictionary<string, object?> Create(Activity activity)
+    {
+        ArgumentNullException.ThrowIfNull(activity);
+
+        return new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["TraceId"] = activity.TraceId.ToString(),
+            ["SpanId"] = activity.SpanId.ToString(),
+        };
+    }
+}

--- a/src/TelemetryBridge/Properties/AssemblyInfo.cs
+++ b/src/TelemetryBridge/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("TelemetryBridge.Tests")]

--- a/src/TelemetryBridge/TelemetryBridge.csproj
+++ b/src/TelemetryBridge/TelemetryBridge.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>CS1591</NoWarn>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcCore" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.4.0-beta.4" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.1" />
+  </ItemGroup>
+</Project>

--- a/src/Todo.DownstreamApi/Controllers/HealthController.cs
+++ b/src/Todo.DownstreamApi/Controllers/HealthController.cs
@@ -1,0 +1,11 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Todo.DownstreamApi.Controllers;
+
+[ApiController]
+[Route("health")]
+public sealed class HealthController : ControllerBase
+{
+    [HttpGet]
+    public IActionResult Get() => Ok("healthy");
+}

--- a/src/Todo.DownstreamApi/Controllers/TodoController.cs
+++ b/src/Todo.DownstreamApi/Controllers/TodoController.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Todo.DownstreamApi.Models;
+using Todo.DownstreamApi.Repositories;
+using Todo.DownstreamApi.Services;
+
+namespace Todo.DownstreamApi.Controllers;
+
+[ApiController]
+[Route("todo")]
+public sealed class TodoController : ControllerBase
+{
+    private readonly ITodoRepository _repository;
+    private readonly TodoMetrics _metrics;
+    private readonly ILogger<TodoController> _logger;
+
+    public TodoController(ITodoRepository repository, TodoMetrics metrics, ILogger<TodoController> logger)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _metrics = metrics ?? throw new ArgumentNullException(nameof(metrics));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public ActionResult<IReadOnlyCollection<TodoItem>> Get()
+    {
+        _logger.LogInformation("Retrieving todo items");
+        var stopwatch = Stopwatch.StartNew();
+        var items = _repository.GetAll().ToArray();
+        stopwatch.Stop();
+
+        _metrics.RecordRead(stopwatch.Elapsed, items.Length);
+        return Ok(items);
+    }
+
+    [HttpPost]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public ActionResult<TodoItem> Post([FromBody] TodoItemRequest request)
+    {
+        if (request is null)
+        {
+            _logger.LogWarning("Received null todo request");
+            return BadRequest(new { error = "Request body required" });
+        }
+
+        if (string.IsNullOrWhiteSpace(request.Title))
+        {
+            _logger.LogWarning("Rejected todo item with empty title");
+            return BadRequest(new { error = "Title is required" });
+        }
+
+        if (string.Equals(request.Title, "panic", StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogCritical("Received todo item that triggers a critical scenario: {Title}", request.Title);
+        }
+
+        try
+        {
+            var item = _repository.Add(request.Title.Trim());
+            _metrics.RecordCreated();
+            _logger.LogInformation("Created todo item {Id}", item.Id);
+            return Created($"/todo/{item.Id}", item);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to create todo item");
+            return StatusCode(StatusCodes.Status500InternalServerError, new { error = "Could not create todo item" });
+        }
+    }
+}

--- a/src/Todo.DownstreamApi/Models/TodoItem.cs
+++ b/src/Todo.DownstreamApi/Models/TodoItem.cs
@@ -1,0 +1,3 @@
+namespace Todo.DownstreamApi.Models;
+
+public sealed record TodoItem(int Id, string Title);

--- a/src/Todo.DownstreamApi/Models/TodoItemRequest.cs
+++ b/src/Todo.DownstreamApi/Models/TodoItemRequest.cs
@@ -1,0 +1,3 @@
+namespace Todo.DownstreamApi.Models;
+
+public sealed record TodoItemRequest(string Title);

--- a/src/Todo.DownstreamApi/Program.cs
+++ b/src/Todo.DownstreamApi/Program.cs
@@ -1,0 +1,22 @@
+using TelemetryBridge;
+using Todo.DownstreamApi.Repositories;
+using Todo.DownstreamApi.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.WebHost.UseUrls("http://localhost:5071");
+
+builder.Services.AddTelemetryBridge("Todo.DownstreamApi");
+builder.Services.AddControllers();
+builder.Services.AddProblemDetails();
+
+builder.Services.AddSingleton<ITodoRepository, InMemoryTodoRepository>();
+builder.Services.AddSingleton<TodoMetrics>();
+
+var app = builder.Build();
+
+app.MapControllers();
+
+app.Run();
+
+public partial class Program;

--- a/src/Todo.DownstreamApi/Repositories/ITodoRepository.cs
+++ b/src/Todo.DownstreamApi/Repositories/ITodoRepository.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using Todo.DownstreamApi.Models;
+
+namespace Todo.DownstreamApi.Repositories;
+
+public interface ITodoRepository
+{
+    IReadOnlyCollection<TodoItem> GetAll();
+
+    TodoItem Add(string title);
+}

--- a/src/Todo.DownstreamApi/Repositories/InMemoryTodoRepository.cs
+++ b/src/Todo.DownstreamApi/Repositories/InMemoryTodoRepository.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading;
+using Todo.DownstreamApi.Models;
+
+namespace Todo.DownstreamApi.Repositories;
+
+public sealed class InMemoryTodoRepository : ITodoRepository
+{
+    private readonly ConcurrentDictionary<int, TodoItem> _items = new();
+    private int _nextId = 0;
+
+    public IReadOnlyCollection<TodoItem> GetAll()
+    {
+        return _items.Values
+            .OrderBy(item => item.Id)
+            .ToArray();
+    }
+
+    public TodoItem Add(string title)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(title);
+        var id = Interlocked.Increment(ref _nextId);
+        var todo = new TodoItem(id, title);
+        if (!_items.TryAdd(id, todo))
+        {
+            throw new InvalidOperationException("Failed to store todo item");
+        }
+
+        return todo;
+    }
+}

--- a/src/Todo.DownstreamApi/Services/TodoMetrics.cs
+++ b/src/Todo.DownstreamApi/Services/TodoMetrics.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Diagnostics.Metrics;
+using TelemetryBridge;
+
+namespace Todo.DownstreamApi.Services;
+
+public sealed class TodoMetrics
+{
+    private readonly Counter<long> _createdCounter;
+    private readonly Histogram<double> _readDurationHistogram;
+    private readonly Histogram<double> _itemCountHistogram;
+
+    public TodoMetrics(IMetricsHandle handle)
+    {
+        ArgumentNullException.ThrowIfNull(handle);
+        _createdCounter = handle.CreateCounter("todo_items_created", description: "Number of todo items created");
+        _readDurationHistogram = handle.CreateHistogram("todo_list_read_duration_ms", unit: "ms", description: "Todo list retrieval duration");
+        _itemCountHistogram = handle.CreateHistogram("todo_list_size", description: "Number of todo items returned");
+    }
+
+    public void RecordCreated() => _createdCounter.Add(1);
+
+    public void RecordRead(TimeSpan duration, int count)
+    {
+        _readDurationHistogram.Record(duration.TotalMilliseconds);
+        _itemCountHistogram.Record(count);
+    }
+}

--- a/src/Todo.DownstreamApi/Todo.DownstreamApi.csproj
+++ b/src/Todo.DownstreamApi/Todo.DownstreamApi.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <ItemGroup>
+    <ProjectReference Include="..\TelemetryBridge\TelemetryBridge.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Todo.MainApi/Controllers/HealthController.cs
+++ b/src/Todo.MainApi/Controllers/HealthController.cs
@@ -1,0 +1,11 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Todo.MainApi.Controllers;
+
+[ApiController]
+[Route("health")]
+public sealed class HealthController : ControllerBase
+{
+    [HttpGet]
+    public IActionResult Get() => Ok("healthy");
+}

--- a/src/Todo.MainApi/Controllers/TodoController.cs
+++ b/src/Todo.MainApi/Controllers/TodoController.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Todo.MainApi.Models;
+using Todo.MainApi.Services;
+
+namespace Todo.MainApi.Controllers;
+
+[ApiController]
+[Route("todo")]
+public sealed class TodoController : ControllerBase
+{
+    private readonly IDownstreamTodoClient _client;
+    private readonly ILogger<TodoController> _logger;
+
+    public TodoController(IDownstreamTodoClient client, ILogger<TodoController> logger)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<ActionResult<IReadOnlyCollection<TodoItem>>> GetAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Fetching todos from downstream");
+        var todos = await _client.GetAllAsync(cancellationToken).ConfigureAwait(false);
+        _logger.LogDebug("Fetched {Count} todos", todos.Count);
+        return Ok(todos);
+    }
+
+    [HttpPost]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+    public async Task<ActionResult<TodoItem>> PostAsync([FromBody] TodoItemRequest request, CancellationToken cancellationToken)
+    {
+        if (request is null)
+        {
+            return BadRequest(new { error = "Request body required" });
+        }
+
+        _logger.LogInformation("Forwarding todo creation to downstream");
+
+        try
+        {
+            var item = await _client.CreateAsync(request, cancellationToken).ConfigureAwait(false);
+            _logger.LogInformation("Downstream created todo {Id}", item.Id);
+            return Created($"/todo/{item.Id}", item);
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "Downstream call failed");
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, new { error = "Downstream API unavailable" });
+        }
+    }
+}

--- a/src/Todo.MainApi/Models/TodoItem.cs
+++ b/src/Todo.MainApi/Models/TodoItem.cs
@@ -1,0 +1,3 @@
+namespace Todo.MainApi.Models;
+
+public sealed record TodoItem(int Id, string Title);

--- a/src/Todo.MainApi/Models/TodoItemRequest.cs
+++ b/src/Todo.MainApi/Models/TodoItemRequest.cs
@@ -1,0 +1,3 @@
+namespace Todo.MainApi.Models;
+
+public sealed record TodoItemRequest(string Title);

--- a/src/Todo.MainApi/Program.cs
+++ b/src/Todo.MainApi/Program.cs
@@ -1,0 +1,24 @@
+using System;
+using TelemetryBridge;
+using Todo.MainApi.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.WebHost.UseUrls("http://localhost:5072");
+
+builder.Services.AddTelemetryBridge("Todo.MainApi");
+builder.Services.AddControllers();
+builder.Services.AddProblemDetails();
+
+builder.Services.AddHttpClient<IDownstreamTodoClient, DownstreamTodoClient>(client =>
+{
+    client.BaseAddress = new Uri("http://localhost:5071");
+});
+
+var app = builder.Build();
+
+app.MapControllers();
+
+app.Run();
+
+public partial class Program;

--- a/src/Todo.MainApi/Services/DownstreamTodoClient.cs
+++ b/src/Todo.MainApi/Services/DownstreamTodoClient.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Todo.MainApi.Models;
+
+namespace Todo.MainApi.Services;
+
+public sealed class DownstreamTodoClient : IDownstreamTodoClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<DownstreamTodoClient> _logger;
+
+    public DownstreamTodoClient(HttpClient httpClient, ILogger<DownstreamTodoClient> logger)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<IReadOnlyList<TodoItem>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Issuing GET /todo to downstream");
+        using var response = await _httpClient.GetAsync("/todo", cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+        var todos = await response.Content.ReadFromJsonAsync<List<TodoItem>>(cancellationToken: cancellationToken).ConfigureAwait(false)
+            ?? new List<TodoItem>();
+        return todos;
+    }
+
+    public async Task<TodoItem> CreateAsync(TodoItemRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        _logger.LogInformation("Issuing POST /todo to downstream");
+        using var response = await _httpClient.PostAsJsonAsync("/todo", request, cancellationToken).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            _logger.LogError("Downstream rejected request: {StatusCode} {Body}", response.StatusCode, body);
+            response.EnsureSuccessStatusCode();
+        }
+
+        var todo = await response.Content.ReadFromJsonAsync<TodoItem>(cancellationToken: cancellationToken).ConfigureAwait(false);
+        return todo ?? throw new InvalidOperationException("Downstream response missing body");
+    }
+}

--- a/src/Todo.MainApi/Services/IDownstreamTodoClient.cs
+++ b/src/Todo.MainApi/Services/IDownstreamTodoClient.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Todo.MainApi.Models;
+
+namespace Todo.MainApi.Services;
+
+public interface IDownstreamTodoClient
+{
+    Task<IReadOnlyList<TodoItem>> GetAllAsync(CancellationToken cancellationToken = default);
+
+    Task<TodoItem> CreateAsync(TodoItemRequest request, CancellationToken cancellationToken = default);
+}

--- a/src/Todo.MainApi/Todo.MainApi.csproj
+++ b/src/Todo.MainApi/Todo.MainApi.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <ItemGroup>
+    <ProjectReference Include="..\TelemetryBridge\TelemetryBridge.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Todo.Worker/Metrics/WorkerMetrics.cs
+++ b/src/Todo.Worker/Metrics/WorkerMetrics.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Diagnostics.Metrics;
+using TelemetryBridge;
+
+namespace Todo.Worker.Metrics;
+
+public sealed class WorkerMetrics
+{
+    private readonly Counter<long> _heartbeatCounter;
+
+    public WorkerMetrics(IMetricsHandle handle)
+    {
+        ArgumentNullException.ThrowIfNull(handle);
+        _heartbeatCounter = handle.CreateCounter("worker_ticks", description: "Number of worker loops executed");
+    }
+
+    public void RecordHeartbeat() => _heartbeatCounter.Add(1);
+}

--- a/src/Todo.Worker/Program.cs
+++ b/src/Todo.Worker/Program.cs
@@ -1,0 +1,16 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using TelemetryBridge;
+using Todo.Worker.Metrics;
+using Todo.Worker.Workers;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services.AddTelemetryBridge("Todo.Worker");
+builder.Services.AddHttpClient("downstream", client => client.BaseAddress = new Uri("http://localhost:5071"));
+builder.Services.AddSingleton<WorkerMetrics>();
+builder.Services.AddHostedService<TelemetryWorker>();
+
+var app = builder.Build();
+await app.RunAsync();

--- a/src/Todo.Worker/Todo.Worker.csproj
+++ b/src/Todo.Worker/Todo.Worker.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+  <ItemGroup>
+    <ProjectReference Include="..\TelemetryBridge\TelemetryBridge.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Todo.Worker/Workers/TelemetryWorker.cs
+++ b/src/Todo.Worker/Workers/TelemetryWorker.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Todo.Worker.Metrics;
+
+namespace Todo.Worker.Workers;
+
+public sealed class TelemetryWorker : BackgroundService
+{
+    private readonly ILogger<TelemetryWorker> _logger;
+    private readonly WorkerMetrics _metrics;
+    private readonly IHttpClientFactory _httpClientFactory;
+
+    public TelemetryWorker(ILogger<TelemetryWorker> logger, WorkerMetrics metrics, IHttpClientFactory httpClientFactory)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _metrics = metrics ?? throw new ArgumentNullException(nameof(metrics));
+        _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await using var timer = new PeriodicTimer(TimeSpan.FromSeconds(10));
+        var tick = 0;
+
+        while (await timer.WaitForNextTickAsync(stoppingToken).ConfigureAwait(false))
+        {
+            tick++;
+            _logger.LogInformation("Worker tick {Tick}", tick);
+            _logger.LogWarning("Worker warning sample at tick {Tick}", tick);
+            _metrics.RecordHeartbeat();
+
+            try
+            {
+                if (tick % 3 == 0)
+                {
+                    throw new InvalidOperationException("Simulated worker failure");
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Worker experienced a simulated error on tick {Tick}", tick);
+            }
+
+            try
+            {
+                var client = _httpClientFactory.CreateClient("downstream");
+                using var response = await client.GetAsync("/health", stoppingToken).ConfigureAwait(false);
+                response.EnsureSuccessStatusCode();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to reach downstream API");
+            }
+        }
+    }
+}

--- a/tests/TelemetryBridge.Tests/AddTelemetryBridgeTests.cs
+++ b/tests/TelemetryBridge.Tests/AddTelemetryBridgeTests.cs
@@ -1,0 +1,18 @@
+using Microsoft.Extensions.DependencyInjection;
+using TelemetryBridge;
+using Xunit;
+
+namespace TelemetryBridge.Tests;
+
+public sealed class AddTelemetryBridgeTests
+{
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    public void AddTelemetryBridge_RejectsBlankServiceName(string? serviceName)
+    {
+        var services = new ServiceCollection();
+        Assert.Throws<ArgumentException>(() => services.AddTelemetryBridge(serviceName!));
+    }
+}

--- a/tests/TelemetryBridge.Tests/OtlpExporterOptionsResolverTests.cs
+++ b/tests/TelemetryBridge.Tests/OtlpExporterOptionsResolverTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using OpenTelemetry.Exporter;
+using TelemetryBridge.Internal.Configuration;
+using Xunit;
+
+namespace TelemetryBridge.Tests;
+
+public sealed class OtlpExporterOptionsResolverTests : IDisposable
+{
+    private readonly Dictionary<string, string?> _originalEnvironment = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["OTEL_EXPORTER_OTLP_ENDPOINT"] = Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT"),
+        ["OTEL_EXPORTER_OTLP_PROTOCOL"] = Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_PROTOCOL"),
+    };
+
+    [Fact]
+    public void Configure_UsesDefaults_WhenEnvVarsMissing()
+    {
+        Environment.SetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT", null);
+        Environment.SetEnvironmentVariable("OTEL_EXPORTER_OTLP_PROTOCOL", null);
+
+        var options = new OtlpExporterOptions();
+        OtlpExporterOptionsResolver.Configure(options);
+
+        Assert.Equal(new Uri("http://localhost:4317"), options.Endpoint);
+        Assert.Equal(OtlpExportProtocol.Grpc, options.Protocol);
+    }
+
+    [Fact]
+    public void Configure_UsesEnvironmentOverrides()
+    {
+        Environment.SetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector:4318");
+        Environment.SetEnvironmentVariable("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf");
+
+        var options = new OtlpExporterOptions();
+        OtlpExporterOptionsResolver.Configure(options);
+
+        Assert.Equal(new Uri("http://collector:4318"), options.Endpoint);
+        Assert.Equal(OtlpExportProtocol.HttpProtobuf, options.Protocol);
+    }
+
+    public void Dispose()
+    {
+        foreach (var (key, value) in _originalEnvironment)
+        {
+            Environment.SetEnvironmentVariable(key, value);
+        }
+    }
+}

--- a/tests/TelemetryBridge.Tests/SampleLoggerCategory.cs
+++ b/tests/TelemetryBridge.Tests/SampleLoggerCategory.cs
@@ -1,0 +1,5 @@
+namespace TestApp;
+
+internal sealed class SampleLoggerCategory
+{
+}

--- a/tests/TelemetryBridge.Tests/TelemetryBridge.Tests.csproj
+++ b/tests/TelemetryBridge.Tests/TelemetryBridge.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\TelemetryBridge\TelemetryBridge.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+</Project>

--- a/tests/TelemetryBridge.Tests/TelemetryLoggerTests.cs
+++ b/tests/TelemetryBridge.Tests/TelemetryLoggerTests.cs
@@ -1,0 +1,41 @@
+using System.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using TelemetryBridge;
+using TestApp;
+using Xunit;
+
+namespace TelemetryBridge.Tests;
+
+public sealed class TelemetryLoggerTests
+{
+    [Fact]
+    public void Logger_AddsSpanEvent_WithDeveloperLogs()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddTelemetryBridge("TestApp");
+
+        using var provider = services.BuildServiceProvider();
+        var logger = provider.GetRequiredService<ILogger<SampleLoggerCategory>>();
+
+        using var activity = new Activity("test");
+        activity.SetIdFormat(ActivityIdFormat.W3C);
+        var original = Activity.Current;
+        activity.Start();
+        Activity.Current = activity;
+
+        var exception = new InvalidOperationException("boom");
+        logger.LogError(exception, "Failure for {Id}", 42);
+
+        activity.Stop();
+        Activity.Current = original;
+
+        var logEvent = Assert.Single(activity.Events);
+        Assert.Equal("log", logEvent.Name);
+        Assert.Contains(logEvent.Tags, tag => tag.Key == "log.severity" && Equals(tag.Value, LogLevel.Error.ToString()));
+        Assert.Contains(logEvent.Tags, tag => tag.Key == "log.category" && Equals(tag.Value, typeof(SampleLoggerCategory).FullName));
+        Assert.Contains(logEvent.Tags, tag => tag.Key == "exception.message" && Equals(tag.Value, exception.Message));
+    }
+
+}


### PR DESCRIPTION
## Summary
- reorganized the TelemetryBridge library into configuration, diagnostics, and logging namespaces while keeping behavior intact
- converted both Todo APIs to controller-based layouts with dedicated models, repositories, and services
- extracted the worker service and metrics into separate files for a clearer project structure

## Testing
- not run (environment lacks the .NET SDK)


------
https://chatgpt.com/codex/tasks/task_e_68e05083368083228b1d2b65a11d1d31