### PR TITLE
Add cache dependency path to .NET setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
         with:
           dotnet-version: ${{ matrix.dotnet }}
           cache: true
+          cache-dependency-path: '**/*.csproj'
 
       - name: Restore
         run: dotnet restore TelemetryBridgeDemo.sln


### PR DESCRIPTION
## Summary
- configure setup-dotnet to compute cache keys using project files

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0667ea7cc83228690a04544404af0