### PR TITLE
Limit workflow to master branch

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,24 @@
+name: .NET
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+    - name: Restore dependencies
+      run: dotnet restore TelemetryBridgeDemo.sln
+    - name: Build
+      run: dotnet build TelemetryBridgeDemo.sln --configuration Release --no-restore -warnaserror
+    - name: Test
+      run: dotnet test TelemetryBridgeDemo.sln --no-build --verbosity normal


### PR DESCRIPTION
## Summary
- update the .NET workflow triggers to use the master branch for pushes and pull requests

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e06e19c55c83228b79ca229e470049