### PR TITLE
Fix build issues in telemetry bridge

### DIFF
--- a/src/TelemetryBridge/Internal/Diagnostics/MetricsHandle.cs
+++ b/src/TelemetryBridge/Internal/Diagnostics/MetricsHandle.cs
@@ -33,12 +33,7 @@ internal sealed class MetricsHandle : IMetricsHandle, IDisposable
     }
 
     private void EnsureNotDisposed()
-    {
-        if (_disposed)
-        {
-            throw new ObjectDisposedException(nameof(MetricsHandle));
-        }
-    }
+        => ObjectDisposedException.ThrowIf(_disposed, this);
 
     public void Dispose()
     {
@@ -47,11 +42,7 @@ internal sealed class MetricsHandle : IMetricsHandle, IDisposable
             return;
         }
 
-        foreach (var instrument in _instruments.Values)
-        {
-            instrument.Dispose();
-        }
-
         _disposed = true;
+        _instruments.Clear();
     }
 }

--- a/src/TelemetryBridge/Internal/Diagnostics/TelemetryResourceBuilder.cs
+++ b/src/TelemetryBridge/Internal/Diagnostics/TelemetryResourceBuilder.cs
@@ -14,7 +14,7 @@ internal static class TelemetryResourceBuilder
     {
         resourceBuilder
             .AddService(serviceName: options.ServiceName, serviceVersion: options.ServiceVersion)
-            .AddAttributes(new KeyValuePair<string, object?>[]
+            .AddAttributes(new KeyValuePair<string, string>[]
             {
                 new("service.instance.id", Environment.MachineName),
             });

--- a/src/TelemetryBridge/Internal/Logging/TelemetryLogEventEmitter.cs
+++ b/src/TelemetryBridge/Internal/Logging/TelemetryLogEventEmitter.cs
@@ -68,7 +68,7 @@ internal sealed class TelemetryLogEventEmitter : ITelemetryLogEventEmitter
             }
         }
 
-        activity.AddEvent(new ActivityEvent("log", tags));
+        activity.AddEvent(new ActivityEvent("log", DateTimeOffset.UtcNow, tags));
     }
 
     private bool ShouldCapture(string category)


### PR DESCRIPTION
## Summary
- ensure telemetry resource attributes are passed as string key/value pairs
- stop disposing metric instruments and use ObjectDisposedException.ThrowIf for guard clauses
- provide a timestamp when emitting telemetry log events

## Testing
- `dotnet build TelemetryBridgeDemo.sln -warnaserror` *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0729e964883228fd6a76b4acbca7b